### PR TITLE
Added improved log settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All changes to the gem are documented here.
 
+## [1.2.4] - 2020-10-06
+
+ - Added `configuration.log_messages_at_least_as` option, to be able debug client behaviour when app log level is higher (eg. production)
+
 ## [1.2.3] - 2020-08-21
 
  - Corrected order in XML `sequence` elements

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ CzechPostB2bClient.configure do |config|
   # config.language => :cs # other languages are not supported now
   # config.logger => ::Rails.logger or ::Logger.new(STDOUT),
   # config.b2b_api_base_uri => 'https://b2b.postaonline.cz/services/POLService/v1'
+  # config.log_messages_at_least_as = :debug
 end
 ```
 

--- a/lib/czech_post_b2b_client.rb
+++ b/lib/czech_post_b2b_client.rb
@@ -5,6 +5,7 @@ require 'stepped_service'
 
 require 'czech_post_b2b_client/version'
 require 'czech_post_b2b_client/configuration'
+require 'czech_post_b2b_client/logger'
 
 require 'czech_post_b2b_client/b2b_errors'
 require 'czech_post_b2b_client/response_codes'
@@ -26,7 +27,7 @@ module CzechPostB2bClient
   end
 
   def self.logger
-    self.configuration.logger
+    CzechPostB2bClient::Logger.new(self.configuration)
   end
 
   def self.root

--- a/lib/czech_post_b2b_client/configuration.rb
+++ b/lib/czech_post_b2b_client/configuration.rb
@@ -16,7 +16,8 @@ module CzechPostB2bClient
                   :logger,
                   :b2b_api_base_uri,
                   :print_options,
-                  :custom_card_number
+                  :custom_card_number,
+                  :log_messages_at_least_as
 
     def initialize
       # set defaults here
@@ -34,6 +35,9 @@ module CzechPostB2bClient
       @logger = defined?(Rails) ? ::Rails.logger : ::Logger.new(STDOUT)
       @b2b_api_base_uri = 'https://b2b.postaonline.cz/services/POLService/v1'
       @sending_post_office_location_number = 1
+
+      # set this to :error in production for API debug logs in production.log
+      @log_messages_at_least_as = :debug # so all logs keeps their level
     end
   end
 end

--- a/lib/czech_post_b2b_client/logger.rb
+++ b/lib/czech_post_b2b_client/logger.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'logger'
+
+module CzechPostB2bClient
+  class Logger
+    attr_reader :target_logger, :min_log_level
+
+    LEVELS = { debug: 0, info: 1, error: 2 }.freeze
+
+    def initialize(configuration)
+      @target_logger = configuration.logger
+      @min_log_level = configuration.log_messages_at_least_as
+    end
+
+    def log(original_level, message)
+      puts("#{message} #{original_level} => #{modified_log_level(original_level)}")
+      target_logger.send(modified_log_level(original_level), message)
+    end
+
+    LEVELS.each_key do |level|
+      define_method(level) { |message| log(level, message) }
+    end
+
+    private
+
+    def modified_log_level(original_level)
+      LEVELS[original_level] > LEVELS[min_log_level] ? original_level : min_log_level
+    end
+  end
+end

--- a/lib/czech_post_b2b_client/request_builders/parcel_service_sync_builder.rb
+++ b/lib/czech_post_b2b_client/request_builders/parcel_service_sync_builder.rb
@@ -29,7 +29,7 @@ module CzechPostB2bClient
 
       def service_data_struct
         new_element('serviceData').tap do |srv_data|
-          add_element_to(srv_data, send_parcels)
+          add_element_to(srv_data, parcel_service_sync)
         end
       end
 
@@ -65,7 +65,7 @@ module CzechPostB2bClient
         end
       end
 
-      def send_parcels
+      def parcel_service_sync
         new_element('ns2:parcelServiceSyncRequest').tap do |ps_sync_request|
           add_element_to(ps_sync_request, do_parcel_header) # REQUIRED
           add_element_to(ps_sync_request, do_parcel_data) # optional

--- a/lib/czech_post_b2b_client/version.rb
+++ b/lib/czech_post_b2b_client/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CzechPostB2bClient
-  VERSION = '1.2.3'
+  VERSION = '1.2.4'
 end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class CzechPostB2bClientTest < Minitest::Test
+  def setup
+    setup_configuration
+  end
+
+  def test_it_respects_minimum_log_level
+    CzechPostB2bClient.configuration.stub(:logger, fake_logger) do
+      CzechPostB2bClient.configuration.stub(:log_messages_at_least_as, :info) do
+        log_messages.each_pair { |level, msg| CzechPostB2bClient.logger.send(level, msg) }
+      end
+    end
+
+    assert_mock fake_logger
+  end
+
+  def fake_logger
+    @fake_logger ||= begin
+      fake_logger = Minitest::Mock.new
+      fake_logger.expect(:info, true, [log_messages[:debug]])
+      fake_logger.expect(:info, true, [log_messages[:info]])
+      fake_logger.expect(:error, true, [log_messages[:error]])
+    end
+  end
+
+  def log_messages
+    @log_messages ||= { debug: 'Debug information',
+                        info: 'Info information',
+                        error: 'Error information' }
+  end
+end

--- a/test/czech_post_b2b_client_test.rb
+++ b/test/czech_post_b2b_client_test.rb
@@ -7,10 +7,6 @@ class CzechPostB2bClientTest < Minitest::Test
     refute_nil ::CzechPostB2bClient::VERSION
   end
 
-  def test_it_does_something_useful
-    assert true
-  end
-
   def test_knows_available_templates
     all_templates = CzechPostB2bClient::PrintingTemplates.all_classes.to_a
 


### PR DESCRIPTION
To be able debug just ApiClient in production, setting `configuration.log_messages_at_least_as = :debug` was added.
- With `:debug` no change at all. 
- With `:info`, all `logger.debug()` messages are passed as `:info` to `configuration.logger`. 
- With `:error`, all `logger.debug()` and `logger.info` messages are passed as `:error` to `configuration.logger`. 
